### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/B/ebe1a0d7-c5a2-408d-b81d-2d825c5a6a0e/659d93fe-0356-410d-81c2-df4a3f4196b0/_apis/work/boardbadge/b7e56b4e-852b-43a6-8ea1-0f6f3912ce3d)](https://codedev.ms/B/ebe1a0d7-c5a2-408d-b81d-2d825c5a6a0e/_boards/board/t/659d93fe-0356-410d-81c2-df4a3f4196b0/Microsoft.RequirementCategory)
 # PublicRepo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/B/ebe1a0d7-c5a2-408d-b81d-2d825c5a6a0e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.